### PR TITLE
fix: if editor form label exists shows insted of field name in wide mode

### DIFF
--- a/lib/usertypeeditor.php
+++ b/lib/usertypeeditor.php
@@ -24,7 +24,7 @@ class UserTypeEditor
         return AdminEditor::init(
             [
                 'uniqId'       => $arUserField['ID'],
-                'editorName'   => $arUserField['FIELD_NAME'],
+                'editorName'   => $arUserField['EDIT_FORM_LABEL'] ?? $arUserField['FIELD_NAME'],
                 'value'        => $arUserField['VALUE'],
                 'inputName'    => $arHtmlControl['NAME'],
                 'userSettings' => $arUserField['SETTINGS'],


### PR DESCRIPTION
Если у пользовательского поля типа Текст задана подпись для формы редактирования - показываем её вместо символьного кода свойства (т.е. вместо UF_DETAIL_TEXT, показываем Детальный текст). Применимо для WideMode.

![image](https://github.com/user-attachments/assets/93cb0a3f-3c56-4407-9ab9-2992155b121f)

