### PR TITLE
Фикс бесконечной загрузки изображения

### DIFF
--- a/lib/uploadhandler.php
+++ b/lib/uploadhandler.php
@@ -325,17 +325,8 @@ class UploadHandler
 
     protected function get_file_name($name, $content_range)
     {
-        // Keep an existing filename if this is part of a chunked upload:
-        $uploaded_bytes = $this->fix_integer_overflow((int)$content_range[1]);
-        while (is_file($this->get_upload_path($name))) {
-            if ($uploaded_bytes === $this->get_file_size(
-                    $this->get_upload_path($name)
-                )
-            ) {
-                break;
-            }
-        }
-        return $name;
+        $pathInfo = pathinfo($this->get_upload_path($name));
+        return $pathInfo['filename'].'.'.$pathInfo['extension'];
     }
 
     protected function handle_file_upload(


### PR DESCRIPTION
На виртуальном хостинге Beget при загрузке некоторых .png процесс загрузки зависает до истечения таймаутов. Данный фикс избавляется от цикла, который приводит к зависанию процесса.