### PR TITLE
Поправили сортировку полей в конструкторе составных блоков

### DIFF
--- a/install/admin/sprint.editor/assets/complex_builder.css
+++ b/install/admin/sprint.editor/assets/complex_builder.css
@@ -1,0 +1,4 @@
+
+.sp-x-toolbar .sp-x-block:first-letter {
+    font-weight: 600;
+}

--- a/lib/complexbuilder.php
+++ b/lib/complexbuilder.php
@@ -51,7 +51,7 @@ class ComplexBuilder
             );
             $blocksToolbar[] = [
                 'title'  => GetMessage('SPRINT_EDITOR_group_' . $groupname),
-                'blocks' => self::sortByNum($filteredBlocks, 'sort'),
+                'blocks' => self::sortByStr($filteredBlocks, 'title'),
             ];
         }
 
@@ -154,6 +154,15 @@ class ComplexBuilder
     {
         usort($input, function ($a, $b) use ($key) {
             return ($a[$key] < $b[$key]) ? -1 : 1;
+        });
+
+        return $input;
+    }
+
+    protected static function sortByStr($input, $key)
+    {
+        usort($input, function ($a, $b) use ($key) {
+            return strcmp($a[$key], $b[$key]);
         });
 
         return $input;

--- a/lib/complexbuilder.php
+++ b/lib/complexbuilder.php
@@ -77,6 +77,7 @@ class ComplexBuilder
         }
 
         Asset::getInstance()->addJs('/bitrix/admin/sprint.editor/assets/complex_builder.js');
+        Asset::getInstance()->addString("<link href='/bitrix/admin/sprint.editor/assets/complex_builder.css' rel='stylesheet' type='text/css'>");
     }
 
     protected static function getGroupPath($groupname, $islocal): string


### PR DESCRIPTION
Поменяли сортировку на алфавитную, добавили подсветку первого символа.

Было:
![before](https://github.com/user-attachments/assets/2779d73b-b116-40ce-b251-671c17cbd799)

Стало:
![after](https://github.com/user-attachments/assets/50ef6af9-64c3-4295-8364-36d51e92dcf4)

См. https://github.com/andreyryabin/sprint.editor/issues/52 (пункт 4)