### PR TITLE
Добавил подключение ключа api Яндекс.Карт из настроек Битрикс

### DIFF
--- a/install/admin/sprint.editor/blocks/yandex_map/getMapApiKey.php
+++ b/install/admin/sprint.editor/blocks/yandex_map/getMapApiKey.php
@@ -1,0 +1,5 @@
+<?php
+require_once($_SERVER["DOCUMENT_ROOT"]."/bitrix/modules/main/include/prolog_before.php");
+echo \Bitrix\Main\Config\Option::get("fileman", "yandex_map_api_key", "");
+require_once($_SERVER['DOCUMENT_ROOT'] . '/bitrix/modules/main/include/epilog_after.php');
+?>

--- a/install/admin/sprint.editor/blocks/yandex_map/script.js
+++ b/install/admin/sprint.editor/blocks/yandex_map/script.js
@@ -43,11 +43,32 @@ sprint_editor.registerBlock('yandex_map', function ($, $el, data) {
         return data;
     };
 
+    var mapApiKey = '';
     this.afterRender = function () {
+        if (mapApiKey) {
+            loadMapWithKey(mapApiKey);
+        } else {
+            fetch('/bitrix/admin/sprint.editor/blocks/yandex_map/getMapApiKey.php')
+                .then(response => response.text())
+                .then(data => {
+                    mapApiKey = data.trim();
+                    loadMapWithKey(mapApiKey);
+                })
+                .catch(() => {
+                    loadMapWithKey('');
+                });
+        }
 
-        $.getScript("https://api-maps.yandex.ru/2.1/?lang=ru_RU&wizard=bitrix", function () {
-            afterLoad()
-        });
+        function loadMapWithKey(key) {
+            var scriptUrl = "https://api-maps.yandex.ru/2.1/?lang=ru_RU&wizard=bitrix";
+            if (key) {
+                scriptUrl += "&apikey=" + encodeURIComponent(key);
+            }
+
+            $.getScript(scriptUrl, function () {
+                afterLoad();
+            });
+        }
     };
 
     function afterLoad() {


### PR DESCRIPTION
Вроде работает как нужно.

![map](https://github.com/user-attachments/assets/ecf822e4-3e66-4dc4-a7ea-ab436eb5d3d7)

см. https://github.com/andreyryabin/sprint.editor/issues/47